### PR TITLE
Make output object compatible with the rest of cmdlets

### DIFF
--- a/src/Functions/Public/workflow-run-service/Invoke-vROWorkflow.ps1
+++ b/src/Functions/Public/workflow-run-service/Invoke-vROWorkflow.ps1
@@ -148,7 +148,7 @@
                     
             StatusCode = $InvokeRequest.StatusCode
             StatusDescription = $InvokeRequest.StatusDescription
-            Execution = $InvokeRequest.Headers.Location
+            Execution = ([System.Uri]$InvokeRequest.Headers.Location[0]).LocalPath
         }
     }
     catch [Exception]{


### PR DESCRIPTION
Let it return an object that can be pipelined to Get-vROWorkflowExecutionState