### PR TITLE
Support getting workflows by tag. If using with 7.x throw an error.

### DIFF
--- a/src/Functions/Public/workflow-service/Get-vROWorkflow.ps1
+++ b/src/Functions/Public/workflow-service/Get-vROWorkflow.ps1
@@ -48,6 +48,9 @@
 
     .EXAMPLE
     Get-vROWorkflow -Name 'New' -Wildcard
+
+    .EXAMPLE
+    Get-vROWorkflow -Tag 'vCenter'
 #>
 [CmdletBinding(DefaultParametersetName="All")][OutputType('System.Management.Automation.PSObject')]
 

--- a/src/Functions/Public/workflow-service/Get-vROWorkflow.ps1
+++ b/src/Functions/Public/workflow-service/Get-vROWorkflow.ps1
@@ -21,6 +21,9 @@
     .PARAMETER Wildcard
     Perform a wildcard search when using the Name parameter
 
+    .PARAMETER Tag
+    Retrieve workflow by Tag
+
     .INPUTS
     System.String
     System.Switch
@@ -65,122 +68,151 @@
     [String]$Name,
 
     [parameter(Mandatory=$false,ParameterSetName="Name")]
-    [Switch]$Wildcard
+    [Switch]$Wildcard,
+
+    [parameter(Mandatory=$false,ParameterSetName="All")]
+    [parameter(Mandatory=$false,ParameterSetName="CategoryName")]
+    [parameter(Mandatory=$false,ParameterSetName="Category")]
+    [String[]]$Tag
 
     )
 
-    try {
+    begin {
 
-        # --- Send REST call and process results
-        switch ($PsCmdlet.ParameterSetName){
+        # --- Verify vRO version supports tagging
+        if ($PSBoundParameters.ContainsKey('Tag') -and $Script:vROConnection.Version -like '7.*') {
 
-            "All" {
-
-                $URI = "/vco/api/workflows"
-                break
-            }
-
-            "CategoryName" {
-
-                $URI = "/vco/api/workflows/?conditions=categoryName=$($CategoryName)"
-                break
-            }
-
-            "CategoryId" {
-
-                $URI = "/vco/api/catalog/System/WorkflowCategory/$($CategoryId)/workflows"
-                break
-            }
-
-            "Id" {
-
-                $URI = "/vco/api/workflows/$($Id)"
-                break
-
-            }
-
-            "Name" {
-
-                if ($PSBoundParameters.ContainsKey('Wildcard')){
-
-                    $URI = "/vco/api/workflows/?conditions=name~$($Name)"
-                }
-                else {
-
-                    $URI = "/vco/api/workflows/?conditions=name=$($Name)"
-                }
-                break
-            }
-        }
-
-        switch ($PsCmdlet.ParameterSetName){
-
-            "Id" {
-
-                $Workflow = Invoke-vRORestMethod -Method Get -Uri $URI -Verbose:$VerbosePreference
-
-                [pscustomobject]@{
-
-                    Name = $Workflow.name
-                    ID = $Workflow.id
-                    Description = $Workflow.description
-                    ItemHref = $Workflow.href
-                    Version = $Workflow.version
-                    CategoryName = $null
-                    CategoryHref = $null
-                    CustomIcon = $Workflow.'customized-icon'
-                    CanExecute = $null
-                    CanEdit = $null
-                }
-            }
-
-            "CategoryId" {
-
-                $Workflows = Invoke-vRORestMethod -Method Get -Uri $URI -Verbose:$VerbosePreference
-
-                foreach ($Workflow in $Workflows.link){
-
-                    [pscustomobject]@{
-
-                        Name = ($Workflow.attributes | Where-Object {$_.name -eq 'name'}).value
-                        ID = ($Workflow.attributes | Where-Object {$_.name -eq 'id'}).value
-                        Description = ($Workflow.attributes | Where-Object {$_.name -eq 'description'}).value
-                        ItemHref = $Workflow.href
-                        Version = ($Workflow.attributes | Where-Object {$_.name -eq 'version'}).value
-                        CategoryName = ($Workflow.attributes | Where-Object {$_.name -eq 'categoryName'}).value
-                        CategoryHref = ($Workflow.attributes | Where-Object {$_.name -eq 'categoryHref'}).value
-                        CustomIcon = ($Workflow.attributes | Where-Object {$_.name -eq 'customIcon'}).value
-                        CanExecute = ($Workflow.attributes | Where-Object {$_.name -eq 'canExecute'}).value
-                        CanEdit = ($Workflow.attributes | Where-Object {$_.name -eq 'canEdit'}).value
-                    }
-                }
-            }
-
-            default {
-
-                $Workflows = Invoke-vRORestMethod -Method Get -Uri $URI -Verbose:$VerbosePreference
-
-                foreach ($Workflow in $Workflows.link){
-
-                    [pscustomobject]@{
-
-                        Name = ($Workflow.attributes | Where-Object {$_.name -eq 'name'}).value
-                        ID = ($Workflow.attributes | Where-Object {$_.name -eq 'id'}).value
-                        Description = ($Workflow.attributes | Where-Object {$_.name -eq 'description'}).value
-                        ItemHref = ($Workflow.attributes | Where-Object {$_.name -eq 'itemHref'}).value
-                        Version = ($Workflow.attributes | Where-Object {$_.name -eq 'version'}).value
-                        CategoryName = ($Workflow.attributes | Where-Object {$_.name -eq 'categoryName'}).value
-                        CategoryHref = ($Workflow.attributes | Where-Object {$_.name -eq 'categoryHref'}).value
-                        CustomIcon = ($Workflow.attributes | Where-Object {$_.name -eq 'customIcon'}).value
-                        CanExecute = ($Workflow.attributes | Where-Object {$_.name -eq 'canExecute'}).value
-                        CanEdit = ($Workflow.attributes | Where-Object {$_.name -eq 'canEdit'}).value
-                    }
-                }
-            }
+            throw "Tagging is not supported with vRO $($Script:vroConnection.Version)."
         }
     }
-    catch [Exception]{
 
-        throw
+    process {
+
+        try {
+
+            # --- Send REST call and process results
+            switch ($PsCmdlet.ParameterSetName){
+    
+                "All" {
+    
+                    $URI = "/vco/api/workflows"
+                    break
+                }
+    
+                "CategoryName" {
+    
+                    $URI = "/vco/api/workflows/?conditions=categoryName=$($CategoryName)"
+                    break
+                }
+    
+                "CategoryId" {
+    
+                    $URI = "/vco/api/catalog/System/WorkflowCategory/$($CategoryId)/workflows"
+                    break
+                }
+    
+                "Id" {
+    
+                    $URI = "/vco/api/workflows/$($Id)"
+                    break
+    
+                }
+    
+                "Name" {
+    
+                    if ($PSBoundParameters.ContainsKey('Wildcard')){
+    
+                        $URI = "/vco/api/workflows/?conditions=name~$($Name)"
+                    }
+                    else {
+    
+                        $URI = "/vco/api/workflows/?conditions=name=$($Name)"
+                    }
+                    break
+                }
+            }
+
+            # filter by tag
+            if ($PSBoundParameters.ContainsKey('Tag')) {
+                $URI += if ($PSCmdlet.ParameterSetName -eq 'All') { '?' } else { '&' }
+    
+                $newParams = @()
+                foreach ($tagAttr in $Tag) {
+                    $newParams += "tags=$($tagAttr)"
+                }
+    
+                $URI += $newParams -join '&'
+            }
+    
+            switch ($PsCmdlet.ParameterSetName){
+    
+                "Id" {
+    
+                    $Workflow = Invoke-vRORestMethod -Method Get -Uri $URI -Verbose:$VerbosePreference
+    
+                    [pscustomobject]@{
+    
+                        Name = $Workflow.name
+                        ID = $Workflow.id
+                        Description = $Workflow.description
+                        ItemHref = $Workflow.href
+                        Version = $Workflow.version
+                        CategoryName = $null
+                        CategoryHref = $null
+                        CustomIcon = $Workflow.'customized-icon'
+                        CanExecute = $null
+                        CanEdit = $null
+                    }
+                }
+    
+                "CategoryId" {
+    
+                    $Workflows = Invoke-vRORestMethod -Method Get -Uri $URI -Verbose:$VerbosePreference
+    
+                    foreach ($Workflow in $Workflows.link){
+    
+                        [pscustomobject]@{
+    
+                            Name = ($Workflow.attributes | Where-Object {$_.name -eq 'name'}).value
+                            ID = ($Workflow.attributes | Where-Object {$_.name -eq 'id'}).value
+                            Description = ($Workflow.attributes | Where-Object {$_.name -eq 'description'}).value
+                            ItemHref = $Workflow.href
+                            Version = ($Workflow.attributes | Where-Object {$_.name -eq 'version'}).value
+                            CategoryName = ($Workflow.attributes | Where-Object {$_.name -eq 'categoryName'}).value
+                            CategoryHref = ($Workflow.attributes | Where-Object {$_.name -eq 'categoryHref'}).value
+                            CustomIcon = ($Workflow.attributes | Where-Object {$_.name -eq 'customIcon'}).value
+                            CanExecute = ($Workflow.attributes | Where-Object {$_.name -eq 'canExecute'}).value
+                            CanEdit = ($Workflow.attributes | Where-Object {$_.name -eq 'canEdit'}).value
+                        }
+                    }
+                }
+    
+                default {
+    
+                    $Workflows = Invoke-vRORestMethod -Method Get -Uri $URI -Verbose:$VerbosePreference
+    
+                    foreach ($Workflow in $Workflows.link){
+    
+                        [pscustomobject]@{
+    
+                            Name = ($Workflow.attributes | Where-Object {$_.name -eq 'name'}).value
+                            ID = ($Workflow.attributes | Where-Object {$_.name -eq 'id'}).value
+                            Description = ($Workflow.attributes | Where-Object {$_.name -eq 'description'}).value
+                            ItemHref = ($Workflow.attributes | Where-Object {$_.name -eq 'itemHref'}).value
+                            Version = ($Workflow.attributes | Where-Object {$_.name -eq 'version'}).value
+                            CategoryName = ($Workflow.attributes | Where-Object {$_.name -eq 'categoryName'}).value
+                            CategoryHref = ($Workflow.attributes | Where-Object {$_.name -eq 'categoryHref'}).value
+                            CustomIcon = ($Workflow.attributes | Where-Object {$_.name -eq 'customIcon'}).value
+                            CanExecute = ($Workflow.attributes | Where-Object {$_.name -eq 'canExecute'}).value
+                            CanEdit = ($Workflow.attributes | Where-Object {$_.name -eq 'canEdit'}).value
+                        }
+                    }
+                }
+            }
+        }
+        catch [Exception]{
+    
+            throw
+        }
     }
 }

--- a/src/Functions/Public/workflow-service/Get-vROWorkflow.ps1
+++ b/src/Functions/Public/workflow-service/Get-vROWorkflow.ps1
@@ -171,7 +171,7 @@
     
                     foreach ($Workflow in $Workflows.link){
     
-                        [pscustomobject]@{
+                        $returnObject = @{
     
                             Name = ($Workflow.attributes | Where-Object {$_.name -eq 'name'}).value
                             ID = ($Workflow.attributes | Where-Object {$_.name -eq 'id'}).value
@@ -184,6 +184,16 @@
                             CanExecute = ($Workflow.attributes | Where-Object {$_.name -eq 'canExecute'}).value
                             CanEdit = ($Workflow.attributes | Where-Object {$_.name -eq 'canEdit'}).value
                         }
+
+                        # add tags if appropriate
+                        $tags = $Workflow.attributes | Where-Object {$_.name -eq 'globalTags'} | Select-Object -ExpandProperty 'value'
+                        if ($tags) {
+
+                            $tagsArray = ($tags -replace ':__SYSTEM_TAG__|.$', '').Split(' ')
+                            $returnObject.Add('Tags', $tagsArray)
+                        }
+
+                        [PSCustomObject]$returnObject
                     }
                 }
     
@@ -193,7 +203,7 @@
     
                     foreach ($Workflow in $Workflows.link){
     
-                        [pscustomobject]@{
+                        $returnObject = @{
     
                             Name = ($Workflow.attributes | Where-Object {$_.name -eq 'name'}).value
                             ID = ($Workflow.attributes | Where-Object {$_.name -eq 'id'}).value
@@ -206,6 +216,16 @@
                             CanExecute = ($Workflow.attributes | Where-Object {$_.name -eq 'canExecute'}).value
                             CanEdit = ($Workflow.attributes | Where-Object {$_.name -eq 'canEdit'}).value
                         }
+
+                        # add tags if appropriate
+                        $tags = $Workflow.attributes | Where-Object {$_.name -eq 'globalTags'} | Select-Object -ExpandProperty 'value'
+                        if ($tags) {
+
+                            $tagsArray = ($tags -replace ':__SYSTEM_TAG__|.$', '').Split(' ')
+                            $returnObject.Add('Tags', $tagsArray)
+                        }
+
+                        [PSCustomObject]$returnObject
                     }
                 }
             }


### PR DESCRIPTION
- Add a `Tag` parameter that supports passing in an array of tags. If multiple tags are passed it is an and operation (has tag1 AND tag2)
- If using the `Tag` parameter with vRO 7.x throw an error and prevent running. I considered making this a warning but then the user may end up with unexpected results when running non-interactively. I put it in the begin block so the check only ran once.
- If vRO returns a globalTags attribute, parse them and return them as an array

This will close #25 and #32.